### PR TITLE
remove .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-export KOVAN_RPC_URL='www.infura.io/asdfadsfafdadf'
-export PRIVATE_KEY='0xabcdef'
-export ALCHEMY_MAINNET_RPC_URL="https://eth-mainnet.alchemyapi.io/v2/your-api-key"


### PR DESCRIPTION
.env was re-introduced with the last commit. Should be removed to avoid issues of users checking in keys