### PR TITLE
Fix test  scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "hardhat test test/unit/PriceConsumerV3_unit_test.js --network hardhat; hardhat test test/unit/APIConsumer_unit_test.js --network hardhat; hardhat test test/unit/RandomNumberConsumer_unit_test.js --network hardhat",
-    "test-integration": "hardhat test test/integration/APIConsumer_int_test.js --network kovan; hardhat test test/integration/RandomNumberConsumer_int_test.js --network kovan",
+    "test": "hardhat test test/unit/PriceConsumerV3_unit_test.js --network hardhat && hardhat test test/unit/APIConsumer_unit_test.js --network hardhat && hardhat test test/unit/RandomNumberConsumer_unit_test.js --network hardhat",
+    "test-integration": "hardhat test test/integration/APIConsumer_int_test.js --network kovan && hardhat test test/integration/RandomNumberConsumer_int_test.js --network kovan",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
## Description
Changing `;` to `&&` fixes the following issue:
```bash
$ yarn test
yarn run v1.22.10
warning ..\package.json: No license field
$ hardhat test test/unit/PriceConsumerV3_unit_test.js --network hardhat; hardhat test test/unit/APIConsumer_unit_test.js --network hardhat; hardhat test test/unit/RandomNumberConsumer_unit_test.js --network hardhat
Error HH309: Repeated parameter --network

For more info go to https://hardhat.org/HH309 or run Hardhat with --show-stack-traces
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Screenshots
As you can see executing the command `yarn test` works on Windows. 
![image](https://user-images.githubusercontent.com/17608169/126909234-5c85c171-1a21-4d89-909e-9ba974c03b10.png)
