### PR TITLE
added support for Polygon testnet and mainnet networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 KOVAN_RPC_URL='https://kovan.infura.io/v3/1234567890'
+MUMBAI_RPC_URL='https://rpc-mumbai.maticvigil.com'
+POLYGON_MAINNET_RPC_URL='https://rpc-mainnet.maticvigil.com'
 PRIVATE_KEY='abcdefg'
 ALCHEMY_MAINNET_RPC_URL="https://eth-mainnet.alchemyapi.io/v2/your-api-key"

--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@
 
 ## Installation
 
+### Kovan Ethereum Testnet
 Set your `KOVAN_RPC_URL` [environment variable.](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html). You can get one for free at [Infura's site.](https://infura.io/) You'll also need to set the variable `MNEMONIC` which is your mnemonic from your wallet, ie MetaMask. This is needed for deploying contracts to public networks. You can optionally set your `PRIVATE_KEY` instead with some changes to the `hardhat.config.js`.
 
+### Matic Mumbai Testnet
+Set your `MUMBAI_RPC_URL` [environment variable](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html). You can get one from the [Matic docs](https://docs.matic.network/docs/develop/network-details/network). You'll also need to set the variable `PRIVATE_KEY` which is your private key from your wallet, ie MetaMask. This is needed for deploying contracts to public networks. You can obtain testnet MATIC and LINK via the [MATIC Faucet](https://faucet.matic.network/)
+
+### Setting Environment Variables
 You can set these in your `.env` file if you're unfamiliar with how setting environment variables work. Check out our [.env example](https://github.com/smartcontractkit/hardhat-starter-kit/blob/main/.env.example). If you wish to use this method to set these variables, update the values in the .env.example file, and then rename it to '.env'
 
 ![WARNING](https://via.placeholder.com/15/f03c15/000000?text=+) **WARNING** ![WARNING](https://via.placeholder.com/15/f03c15/000000?text=+)
@@ -31,12 +36,16 @@ Don't commit and push any changes to .env files that may contain sensitive infor
 KOVAN_RPC_URL='www.infura.io/asdfadsfafdadf'
 MNEMONIC='cat dog frog...'
 MAINNET_RPC_URL="https://eth-mainnet.alchemyapi.io/v2/your-api-key"
+MUMBAI_RPC_URL='https://rpc-mumbai.maticvigil.com'
+POLYGON_MAINNET_RPC_URL='https://rpc-mainnet.maticvigil.com'
 ```
 `bash` example
 ```
 export KOVAN_RPC_URL='www.infura.io/asdfadsfafdadf'
 export MNEMONIC='cat dog frog...'
-export MAINNET_RPC_URL="https://eth-mainnet.alchemyapi.io/v2/your-api-key"
+export MAINNET_RPC_URL='https://eth-mainnet.alchemyapi.io/v2/your-api-key'
+export MUMBAI_RPC_URL='https://rpc-mumbai.maticvigil.com'
+export POLYGON_MAINNET_RPC_URL='https://rpc-mainnet.maticvigil.com'
 ```
 
 If you plan on deploying to a local [Hardhat network](https://hardhat.org/hardhat-network/) that's a fork of the Ethereum mainnet instead of a public test network like Kovan, you'll also need to set your `MAINNET_RPC_URL` [environment variable.](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html) and uncomment the `forking` section in `hardhat.config.js`. You can get one for free at [Alchemy's site.](https://alchemyapi.io/).

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -22,6 +22,8 @@ require('dotenv').config()
 const MAINNET_RPC_URL = process.env.MAINNET_RPC_URL || process.env.ALCHEMY_MAINNET_RPC_URL || "https://eth-mainnet.alchemyapi.io/v2/your-api-key"
 const RINKEBY_RPC_URL = process.env.RINKEBY_RPC_URL || "https://eth-rinkeby.alchemyapi.io/v2/your-api-key"
 const KOVAN_RPC_URL = process.env.KOVAN_RPC_URL || "https://eth-kovan.alchemyapi.io/v2/your-api-key"
+const MUMBAI_RPC_URL = process.env.MUMBAI_RPC_URL
+const POLYGON_MAINNET_RPC_URL = process.env.POLYGON_MAINNET_RPC_URL
 const MNEMONIC = process.env.MNEMONIC || "your mnemonic"
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY || "Your etherscan API key"
 // optional
@@ -66,6 +68,16 @@ module.exports = {
             accounts: {
                 mnemonic: MNEMONIC,
             },
+            saveDeployments: true,
+        },
+        mumbai: {
+            url: MUMBAI_RPC_URL,
+            accounts: [PRIVATE_KEY],
+            saveDeployments: true,
+        },
+        polygon: {
+            url: POLYGON_MAINNET_RPC_URL,
+            accounts: [PRIVATE_KEY],
             saveDeployments: true,
         },
     },

--- a/helper-hardhat-config.js
+++ b/helper-hardhat-config.js
@@ -44,7 +44,29 @@ const networkConfig = {
         name: 'goerli',
         linkToken: '0x326c977e6efc84e512bb9c30f76e30c160ed06fb',
         fundAmount: "0"
-    }
+    },
+    80001: {
+        name: 'mumbai',
+        linkToken: '0x326C977E6efc84E512bB9C30f76E30c160eD06FB',
+        ethUsdPriceFeed: '0x0715A7794a1dc8e42615F059dD6e406A6594651A',
+        keyHash: '0x6e75b569a01ef56d18cab6a8e71e6600d6ce853834d4a5748b720d06f878b3a4',
+        vrfCoordinator: '0x8C7382F9D8f56b33781fE506E897a4F1e2d17255',
+        oracle: '0x58bbdbfb6fca3129b91f0dbe372098123b38b5e9',
+        jobId: 'da20aae0e4c843f6949e5cb3f7cfe8c4',
+        fee: '100000000000000',
+        fundAmount: "100000000000000"
+    },
+    137: {
+        name: 'polygon',
+        linkToken: '0xb0897686c545045afc77cf20ec7a532e3120e0f1',
+        ethUsdPriceFeed: '0xF9680D99D6C9589e2a93a78A04A279e509205945',
+        keyHash: '0xf86195cf7690c55907b2b611ebb7343a6f649bff128701cc542f0569e2c549da',
+        vrfCoordinator: '0x3d2341ADb2D31f1c5530cDC622016af293177AE0',
+        oracle: '0x0a31078cd57d23bf9e8e8f1ba78356ca2090569e',
+        jobId: '12b86114fa9e46bab3ca436f88e1a912',
+        fee: '100000000000000',
+        fundAmount: "100000000000000"
+    },
 }
 
 const developmentChains = ["hardhat", "localhost"]


### PR DESCRIPTION
Modified starter kit config to support the Polygon mainnet and the Mumbai testnet, including adding environment specific entries to the config files, and an update to the README