### PR TITLE
Use LINK token version 0.4 

### DIFF
--- a/contracts/test/LinkToken.sol
+++ b/contracts/test/LinkToken.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.6;
+pragma solidity ^0.4.24;
 
-import "@chainlink/token/contracts/v0.6/LinkToken.sol";
+import "@chainlink/token/contracts/v0.4/LinkToken.sol";


### PR DESCRIPTION
See #34

> Version 0.6 of the LINK token imports openzeppelin contracts, which can cause conflicts when others want to use OZ packages.
> Default to the mock contract using v0.4 of solidity to avoid collision