### PR TITLE
@chainlink/contracts Version is invalid.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@appliedblockchain/chainlink-contracts": "0.0.4",
     "@appliedblockchain/chainlink-plugins-fund-link": "0.0.1",
-    "@chainlink/contracts": "^0.2.23",
+    "@chainlink/contracts": "^0.2.2",
     "@chainlink/test-helpers": "0.0.5",
     "@chainlink/token": "^1.1.0",
     "@nomiclabs/hardhat-truffle5": "^2.0.0",


### PR DESCRIPTION
"@chainlink/contracts": "^0.2.23", -> "@chainlink/contracts": "^0.2.2"

Version 0.2.23 is either an internal build you have, but it isn't available on NPM and causes an install failure. Feel free to ignore if that is being pushed, but just noticed it today on cloning a new version of this repo.

![image](https://user-images.githubusercontent.com/3456318/138568982-bacbeb32-9297-4e90-8e06-51aab31ab3d6.png)

![image](https://user-images.githubusercontent.com/3456318/138568998-1c8f9528-6782-40d8-8d63-298415f86aed.png)
