### PR TITLE
updated tests timeout

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -115,7 +115,7 @@ module.exports = {
         ]
     },
     mocha: {
-        timeout: 100000
+        timeout: 300000
     }
 }
 


### PR DESCRIPTION
running integration tests sometimes timeouts due to Kovan network congestion etc (plus we have a 60 second wait in the tests to wait for the callback transaction). Have found I need to increase the timeout to ensure tests don't timeout. 