### PR TITLE
Add hardhat-gas-reporter plugin [Fixes #57]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ KOVAN_RPC_URL='https://kovan.infura.io/v3/1234567890'
 POLYGON_MAINNET_RPC_URL='https://rpc-mainnet.maticvigil.com'
 PRIVATE_KEY='abcdefg'
 ALCHEMY_MAINNET_RPC_URL="https://eth-mainnet.alchemyapi.io/v2/your-api-key"
+REPORT_GAS=true

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ KOVAN_RPC_URL='www.infura.io/asdfadsfafdadf'
 PRIVATE_KEY='abcdef'
 MAINNET_RPC_URL="https://eth-mainnet.alchemyapi.io/v2/your-api-key"
 POLYGON_MAINNET_RPC_URL='https://rpc-mainnet.maticvigil.com'
+REPORT_GAS=true
 ```
 `bash` example
 ```
@@ -42,6 +43,7 @@ export KOVAN_RPC_URL='www.infura.io/asdfadsfafdadf'
 export PRIVATE_KEY='abcdef'
 export MAINNET_RPC_URL='https://eth-mainnet.alchemyapi.io/v2/your-api-key'
 export POLYGON_MAINNET_RPC_URL='https://rpc-mainnet.maticvigil.com'
+export REPORT_GAS=true
 ```
 
 If you plan on deploying to a local [Hardhat network](https://hardhat.org/hardhat-network/) that's a fork of the Ethereum mainnet instead of a public test network like Kovan, you'll also need to set your `MAINNET_RPC_URL` [environment variable.](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html) and uncomment the `forking` section in `hardhat.config.js`. You can get one for free at [Alchemy's site.](https://alchemyapi.io/).

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -88,7 +88,7 @@ module.exports = {
 		},
     },
     gasReporter: {
-        enabled: process.env.REPORT_GAS !== undefined,
+        enabled: process.env.REPORT_GAS ? true : false,
         currency: "USD",
     },
     namedAccounts: {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ethers": "^5.5.1",
     "hardhat": "^2.6.7",
     "hardhat-deploy": "^0.7.0-beta.39",
-    "hardhat-gas-reporter": "^1.0.4",
+    "hardhat-gas-reporter": "^1.0.7",
     "prettier": "^2.4.1",
     "prettier-plugin-solidity": "^1.0.0-beta.13",
     "solhint": "^3.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3567,7 +3567,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@^1.1.2, colors@^1.4.0:
+colors@1.4.0, colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -4801,15 +4801,15 @@ eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.0, eth-ens-namehash@^2.0.8:
     idna-uts46-hx "^2.3.1"
     js-sha3 "^0.5.7"
 
-eth-gas-reporter@^0.2.23:
-  version "0.2.23"
-  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.23.tgz#7a2a412b41285298cdad810cf54adac11d406208"
-  integrity sha512-T8KsVakDEupvQxW3MfFfHDfJ7y8zl2+XhyEQk4hZ3qQsAh/FE27BfFHM9UhqNQvrJLz8zVWnPZWNcARwLT/lsA==
+eth-gas-reporter@^0.2.24:
+  version "0.2.24"
+  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.24.tgz#768721fec7de02b566e4ebfd123466d275d7035c"
+  integrity sha512-RbXLC2bnuPHzIMU/rnLXXlb6oiHEEKu7rq2UrAX/0mfo0Lzrr/kb9QTjWjfz8eNvc+uu6J8AuBwI++b+MLNI2w==
   dependencies:
     "@ethersproject/abi" "^5.0.0-beta.146"
     "@solidity-parser/parser" "^0.14.0"
     cli-table3 "^0.5.0"
-    colors "^1.1.2"
+    colors "1.4.0"
     ethereumjs-util "6.2.0"
     ethers "^4.0.40"
     fs-readdir-recursive "^1.1.0"
@@ -6229,13 +6229,13 @@ hardhat-deploy@^0.7.0-beta.39:
     murmur-128 "^0.2.1"
     qs "^6.9.4"
 
-hardhat-gas-reporter@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.6.tgz#699bc0bb96e8c962c7f136a1c1f29cd3c32d569e"
-  integrity sha512-LlCEmSx1dZpnxKmODb2hmP5eJ1IAM5It3NnBNTUpBTxn9g9qPPI3JQTxj8AbGEiNc3r6V+w/mXYCmiC8pWvnoQ==
+hardhat-gas-reporter@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.7.tgz#b0e06a4f5a4da2369354991b6fa32ff002170573"
+  integrity sha512-calJH1rbhUFwCnw0odJb3Cw+mDmBIsHdVyutsHhA3RY6JELyFVaVxCnITYGr/crkmHqt4tQCYROy7ty6DTLkuA==
   dependencies:
     array-uniq "1.0.3"
-    eth-gas-reporter "^0.2.23"
+    eth-gas-reporter "^0.2.24"
     sha1 "^1.1.1"
 
 hardhat@^2.6.7:


### PR DESCRIPTION
Added `hardhat-gas-reporter` plugin. To enable it, as stated in both `README.md` and `.env.example`, one needs to add the following line.
```
REPORT_GAS=true
```
## Description
- Bumped `hardhat-gas-reporter` plugin version
- Added config for the plugin to `hardhat.config.js` file
- Added an explanation to the README file how to activate the plugin

## Related issue
The related issue is #57 