### PR TITLE
Removed unnecessary usage of Link token interface

### DIFF
--- a/contracts/RandomNumberConsumerV2.sol
+++ b/contracts/RandomNumberConsumerV2.sol
@@ -2,7 +2,6 @@
 // An example of a consumer contract that relies on a subscription for funding.
 pragma solidity ^0.8.7;
 
-import "@chainlink/contracts/src/v0.8/interfaces/LinkTokenInterface.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol";
 import "@chainlink/contracts/src/v0.8/VRFConsumerBaseV2.sol";
 
@@ -12,7 +11,6 @@ import "@chainlink/contracts/src/v0.8/VRFConsumerBaseV2.sol";
  */
 contract RandomNumberConsumerV2 is VRFConsumerBaseV2 {
   VRFCoordinatorV2Interface immutable COORDINATOR;
-  LinkTokenInterface immutable LINKTOKEN;
 
   // Your subscription ID.
   uint64 immutable s_subscriptionId;
@@ -53,11 +51,9 @@ contract RandomNumberConsumerV2 is VRFConsumerBaseV2 {
   constructor(
     uint64 subscriptionId,
     address vrfCoordinator,
-    address link,
     bytes32 keyHash
   ) VRFConsumerBaseV2(vrfCoordinator) {
     COORDINATOR = VRFCoordinatorV2Interface(vrfCoordinator);
-    LINKTOKEN = LinkTokenInterface(link);
     s_keyHash = keyHash;
     s_owner = msg.sender;
     s_subscriptionId = subscriptionId;

--- a/deploy/03_Deploy_RandomNumberConsumer.js
+++ b/deploy/03_Deploy_RandomNumberConsumer.js
@@ -10,16 +10,13 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   const { deploy, get, log } = deployments
   const { deployer } = await getNamedAccounts()
   const chainId = network.config.chainId
-  let linkTokenAddress
   let vrfCoordinatorAddress
   let subscriptionId
 
   if (chainId == 31337) {
-    linkToken = await get("LinkToken")
     VRFCoordinatorV2Mock = await ethers.getContract("VRFCoordinatorV2Mock")
 
     vrfCoordinatorAddress = VRFCoordinatorV2Mock.address
-    linkTokenAddress = linkToken.address
 
     const fundAmount = networkConfig[chainId]["fundAmount"]
     const transaction = await VRFCoordinatorV2Mock.createSubscription()
@@ -28,14 +25,13 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     await VRFCoordinatorV2Mock.fundSubscription(subscriptionId, fundAmount)
   } else {
     subscriptionId = process.env.VRF_SUBSCRIPTION_ID
-    linkTokenAddress = networkConfig[chainId]["linkToken"]
     vrfCoordinatorAddress = networkConfig[chainId]["vrfCoordinator"]
   }
   const keyHash = networkConfig[chainId]["keyHash"]
   const waitBlockConfirmations = developmentChains.includes(network.name)
     ? 1
     : VERIFICATION_BLOCK_CONFIRMATIONS
-  const args = [subscriptionId, vrfCoordinatorAddress, linkTokenAddress, keyHash]
+  const args = [subscriptionId, vrfCoordinatorAddress, keyHash]
   const randomNumberConsumerV2 = await deploy("RandomNumberConsumerV2", {
     from: deployer,
     args: args,


### PR DESCRIPTION
Link token interface was referenced in `RandomNumberConsumerV2` contract and therefore also required by the deploy script. However, for VRF v2 to provide randomness, a consuming contract does not need to be aware of the Link token, as payment for the service is handled on subscription level.

I removed dependencies on Link contract, to make the code leaner and gas friendly 😎