### PR TITLE
Declared constants using `constants` keyword

### DIFF
--- a/contracts/RandomNumberConsumerV2.sol
+++ b/contracts/RandomNumberConsumerV2.sol
@@ -26,14 +26,14 @@ contract RandomNumberConsumerV2 is VRFConsumerBaseV2 {
   // this limit based on the network that you select, the size of the request,
   // and the processing of the callback request in the fulfillRandomWords()
   // function.
-  uint32 immutable s_callbackGasLimit = 100000;
+  uint32 constant s_callbackGasLimit = 100000;
 
   // The default is 3, but you can set this higher.
-  uint16 immutable s_requestConfirmations = 3;
+  uint16 constant s_requestConfirmations = 3;
 
   // For this example, retrieve 2 random values in one request.
   // Cannot exceed VRFCoordinatorV2.MAX_NUM_WORDS.
-  uint32 immutable s_numWords = 2;
+  uint32 constant s_numWords = 2;
 
   uint256[] public s_randomWords;
   uint256 public s_requestId;

--- a/contracts/RandomNumberConsumerV2.sol
+++ b/contracts/RandomNumberConsumerV2.sol
@@ -26,14 +26,14 @@ contract RandomNumberConsumerV2 is VRFConsumerBaseV2 {
   // this limit based on the network that you select, the size of the request,
   // and the processing of the callback request in the fulfillRandomWords()
   // function.
-  uint32 constant s_callbackGasLimit = 100000;
+  uint32 constant CALLBACK_GAS_LIMIT = 100000;
 
   // The default is 3, but you can set this higher.
-  uint16 constant s_requestConfirmations = 3;
+  uint16 constant REQUEST_CONFIRMATIONS = 3;
 
   // For this example, retrieve 2 random values in one request.
   // Cannot exceed VRFCoordinatorV2.MAX_NUM_WORDS.
-  uint32 constant s_numWords = 2;
+  uint32 constant NUM_WORDS = 2;
 
   uint256[] public s_randomWords;
   uint256 public s_requestId;
@@ -68,9 +68,9 @@ contract RandomNumberConsumerV2 is VRFConsumerBaseV2 {
     s_requestId = COORDINATOR.requestRandomWords(
       s_keyHash,
       s_subscriptionId,
-      s_requestConfirmations,
-      s_callbackGasLimit,
-      s_numWords
+      REQUEST_CONFIRMATIONS,
+      CALLBACK_GAS_LIMIT,
+      NUM_WORDS
     );
   }
 


### PR DESCRIPTION
Unlike immutable variables `s_subscriptionId` and `s_keyHash` whose values are provided during contract deployment as arguments, the contract defines in advance the values for `s_callbackGasLimit`, `s_requestConfirmations` and `s_numWords`. Therefore, it makes more sense to declare those 3 as `constant` instead of `immutable`.

As per Solidity documentation:

> Immutable variables are evaluated once at construction time and their value is copied to all the places in the code where they are accessed. For these values, 32 bytes are reserved, even if they would fit in fewer bytes. Due to this, constant values can sometimes be cheaper than immutable values.

https://docs.soliditylang.org/en/latest/contracts.html?#constant-and-immutable-state-variables