### PR TITLE
Fixes the typo in README on estimating gas

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - [View Contracts Size](#view-contracts-size)
 - [Linting](#linting)
 - [Code Formating](#code-formating)
-- [Estimaging Gas](#estimaging-gas)
+- [Estimating Gas](#estimaging-gas)
 - [Code Coverage](#code-coverage)
 - [Fuzzing](#fuzzing)
 - [Contributing](#contributing)


### PR DESCRIPTION
This change fixes the typo in the README file of the topic 'estimaging gas' to 'estimating gas'