### PR TITLE
Changing dependency hw-transport-node-hid's version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -155,7 +155,7 @@
     semaphore-async-await "^1.5.1"
     web3-provider-engine "14.0.6"
   optionalDependencies:
-    "@ledgerhq/hw-transport-node-hid" "^4.3.0"
+    "@ledgerhq/hw-transport-node-hid" "^5.26.0"
 
 "@0x/types@^3.3.4":
   version "3.3.4"


### PR DESCRIPTION
Changing `@ledgerhq/hw-transport-node-hid` dependency version to `^5.26.0` in order to avoid build breaks with latest yarn/node versions.

Quick-fixes #115 