### PR TITLE
Added evm_mine to Keepers tests

### DIFF
--- a/test/unit/KeepersCounter.spec.ts
+++ b/test/unit/KeepersCounter.spec.ts
@@ -30,6 +30,7 @@ import { KeepersCounter } from "../../typechain"
         const checkData = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(""))
         const interval: BigNumber = await counter.interval()
         await network.provider.send("evm_increaseTime", [interval.toNumber() + 1])
+        await network.provider.send("evm_mine");
         await counter.performUpkeep(checkData)
         assert.equal(startingCount.toNumber() + 1, (await counter.counter()).toNumber())
       })


### PR DESCRIPTION
 Added the line await network.provider.send("evm_mine"); below evm_increaseTime, on the typescript keepers test file.