### PR TITLE
Add evm_mine call to the KeepersCounter unit test on JavaScript branch

### DIFF
--- a/test/unit/KeepersCounter_unit_test.js
+++ b/test/unit/KeepersCounter_unit_test.js
@@ -26,6 +26,7 @@ const { developmentChains } = require("../../helper-hardhat-config")
         const checkData = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(""))
         const interval = await counter.interval()
         await network.provider.send("evm_increaseTime", [interval.toNumber() + 1])
+        await network.provider.send("evm_mine");
         await counter.performUpkeep(checkData)
         assert.equal(startingCount + 1, (await counter.counter()).toNumber())
       })


### PR DESCRIPTION
## Description
Added `evm_mine` call after `evm_increaseTime` to the KeepersCounter unit test on a JavaScript (main) branch. The same this was done for the TypeScript branch in #118 

## Related issues
- Closes #95 