### PR TITLE
RandomNumberConsumer deploy script adds randomNumberConsumerV2 as a consumer

### DIFF
--- a/deploy/03_Deploy_RandomNumberConsumer.js
+++ b/deploy/03_Deploy_RandomNumberConsumer.js
@@ -39,6 +39,10 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     waitConfirmations: waitBlockConfirmations,
   })
 
+  if (chainId === 31337) {
+    await VRFCoordinatorV2Mock.addConsumer(subscriptionId, randomNumberConsumerV2.address)
+  }
+
   if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
     log("Verifying...")
     await verify(randomNumberConsumerV2.address, args)


### PR DESCRIPTION
This PR fixes the `RandomNumberConsumer` deploy script. Currently, the deploy script doesn't add `randomNumberConsumerV2` as a consumer when using hardhat, meaning that the first time someone runs `npm test` the VRF tests will fail.

These changes are already incorporated in @0xZarko's PR #123, but that PR looks like it needs a little work before it's merge-able, so I wanted to break out this change so that at least all tests are passing in the meantime.