### PR TITLE
private_key to wallet_private_key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 POLYGON_MAINNET_RPC_URL='https://rpc-mainnet.maticvigil.com'
 MUMBAI_RPC_URL='https://polygon-mumbai.g.alchemy.com/v2/1234567890'
 SEPOLIA_RPC_URL='https://sepolia.infura.io/v3/1234567890'
-PRIVATE_KEY='abcdefg'
+WALLET_PRIVATE_KEY='abcdefg'
 ALCHEMY_MAINNET_RPC_URL="https://eth-mainnet.alchemyapi.io/v2/your-api-key"
 REPORT_GAS=true
 COINMARKETCAP_API_KEY="YOUR_KEY"


### PR DESCRIPTION
Changed PRIVATE_KEY to WALLET_PRIVATE_KEY in .env.example to avoid confusions.