### PR TITLE
fix: incorrect async call to toString method

### DIFF
--- a/helper-functions.js
+++ b/helper-functions.js
@@ -18,7 +18,7 @@ const autoFundCheck = async (contractAddr, networkName, linkTokenAddress, additi
     const balanceBN = await linkTokenContract.balanceOf(signer.address)
     const balance = balanceBN.toString()
     const contractBalanceBN = await linkTokenContract.balanceOf(contractAddr)
-    const contractBalance = await contractBalanceBN.toString()
+    const contractBalance = contractBalanceBN.toString()
     if (balance > amount && amount > 0 && contractBalance < amount) {
         //user has enough LINK to auto-fund
         //and the contract isn't already funded


### PR DESCRIPTION
This PR addresses an issue where the `toString` method was erroneously called as an async function. Since `toString` is a synchronous operation, this commit corrects the call to ensure it is executed in the proper synchronous context, improving code reliability and maintainability.
